### PR TITLE
Add Atom One Dark Syntax file

### DIFF
--- a/atom-one-dark.ini
+++ b/atom-one-dark.ini
@@ -1,0 +1,20 @@
+; Based on One Dark Syntax and UI theme for GitHub's Atom text editor
+; One Dark Syntax Copyright (c) 2016 GitHub Inc https://github.com/atom/one-dark-syntax
+; One Dark UI © Copyright (c) 2014 GitHub Inc. https://github.com/atom/one-dark-ui
+atom/one/dark/name = Atom One Dark
+atom/one/dark/background = #282c34
+atom/one/dark/currentline = #0A99bbff
+atom/one/dark/currentcell = #00000000
+atom/one/dark/occurrence = #373b41
+atom/one/dark/ctrlclick = #56b6c2
+atom/one/dark/sideareas = #21252b
+atom/one/dark/matched_p = #373b41
+atom/one/dark/unmatched_p = #ff9999
+atom/one/dark/normal = ('#abb2bf', False, False)
+atom/one/dark/keyword = ('#c678dd', False, False)
+atom/one/dark/builtin = ('#d19a66', False, False)
+atom/one/dark/definition = ('#61afef', True, False)
+atom/one/dark/comment = ('#969896', False, True)
+atom/one/dark/string = ('#98c379', False, False)
+atom/one/dark/number = ('#d19a66', False, False)
+atom/one/dark/instance = ('#8abeb7', False, True)


### PR DESCRIPTION
Your work with the GitHub and Tomorrow Night themes for [Spyder](https://github.com/spyder-ide/spyder) increased the number of quality themes, especially dark ones. I'd like to add one.

This [Spyder](https://github.com/spyder-ide/spyder) theme is based on the Atom One dark [UI](https://github.com/atom/one-dark-ui) and [syntax](https://github.com/atom/one-dark-syntax) theme for GitHub's Atom text editor.

I didn't dig in to the smaller syntax features, like ctrlclick, occurrence, unmatched_p, etc., so I may be able to add a few more colors and tighten up the theme.