### PR TITLE
Andew pyle/atom one dark

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,6 +8,7 @@ Color schemes for [[https://github.com/spyder-ide/spyder][Spyder]].
 - [[https://github.com/chriskempson/tomorrow-theme][Tomorrow theme]]:
   - Tomorrow
   - Tomorrow Night
+- Atom One Dark (based on [[https://atom.io/][Github's Atom Text Editor]])
 
 * How to install
 1. With Spyder closed, open =~/.spyder-py3/spyder.ini=.

--- a/README.org
+++ b/README.org
@@ -11,15 +11,17 @@ Color schemes for [[https://github.com/spyder-ide/spyder][Spyder]].
 - Atom One Dark (based on [[https://atom.io/][Github's Atom Text Editor]])
 
 * How to install
-1. With Spyder closed, open =~/.spyder-py3/spyder.ini=.
-2. Find =[color_schemes]= section. Add =ColorSchemeName= to the names list. For example:
+1. Choose one of the themes in this repository according to the theme list above.
+2. Locate the theme's =ColorSchemeName.ini= file in this repository. For example, =tomorrow.ini=.
+3. With Spyder closed, open =~/.spyder-py3/spyder.ini=.
+4. Find =[color_schemes]= section. Add =ColorSchemeName= to the names list. For example:
 
    #+BEGIN_SRC ini
       [color_schemes]
       names = ['emacs', 'idle', 'monokai', 'pydev', 'scintilla', 'solarized/dark', 'solarized/light', 'spyder', 'spyder/dark', 'tomorrow', 'zenburn']
    #+END_SRC
 
-3. Append the color scheme settings to the end of =[color_schemes]= section. For example:
+5. Append your chosen color scheme settings from the =ColorSchemeName.ini= file in this repositiory to the end of =[color_schemes]= section. For example:
 
    #+BEGIN_SRC ini
       ...
@@ -45,5 +47,5 @@ Color schemes for [[https://github.com/spyder-ide/spyder][Spyder]].
       tomorrow/currentcell = '#ffffff'
    #+END_SRC
 
-4. The new color scheme will be available in the =Tools= -> =Preferences=
+6. The new color scheme will be available in the =Tools= -> =Preferences=
    -> =Syntax coloring=.

--- a/atom-one-dark.ini
+++ b/atom-one-dark.ini
@@ -1,20 +1,20 @@
-; Based on One Dark Syntax and UI theme for GitHub's Atom text editor
+; Based on One Dark Syntax v1.8.0 and One Dark UI v1.10.8 themes for GitHub's Atom text editor
 ; One Dark Syntax Copyright (c) 2016 GitHub Inc https://github.com/atom/one-dark-syntax
 ; One Dark UI © Copyright (c) 2014 GitHub Inc. https://github.com/atom/one-dark-ui
 atom/one/dark/name = Atom One Dark
 atom/one/dark/background = #282c34
 atom/one/dark/currentline = #0A99bbff
 atom/one/dark/currentcell = #00000000
-atom/one/dark/occurrence = #373b41
+atom/one/dark/occurrence = #434957
 atom/one/dark/ctrlclick = #56b6c2
 atom/one/dark/sideareas = #21252b
-atom/one/dark/matched_p = #373b41
-atom/one/dark/unmatched_p = #ff9999
+atom/one/dark/matched_p = #434957
+atom/one/dark/unmatched_p = #4Dff0000
 atom/one/dark/normal = ('#abb2bf', False, False)
 atom/one/dark/keyword = ('#c678dd', False, False)
-atom/one/dark/builtin = ('#d19a66', False, False)
-atom/one/dark/definition = ('#61afef', True, False)
-atom/one/dark/comment = ('#969896', False, True)
+atom/one/dark/builtin = ('#56b6c2', False, False)
+atom/one/dark/definition = ('#61afef', False, False)
+atom/one/dark/comment = ('#5c6370', False, True)
 atom/one/dark/string = ('#98c379', False, False)
 atom/one/dark/number = ('#d19a66', False, False)
-atom/one/dark/instance = ('#8abeb7', False, True)
+atom/one/dark/instance = ('#e5c07b', False, True)


### PR DESCRIPTION
I updated the README.org file to include the Atom One Dark syntax for Spyder. I also updated the instructions in the README for installing the themes. I think this makes them more clear. Feel free to revise or discard.

I also improved the syntax highlighting in the Atom One Dark theme itself.